### PR TITLE
Fix PutChar

### DIFF
--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -102,9 +102,7 @@ fn put_char(args: Vec<RickrollObject>, writer: &mut dyn Write, _: &mut dyn BufRe
     }
     let chr = args[0].clone();
     if let RickrollObject::Char(x) = chr {
-        let mut buffer: [u8; 4] = [0; 4];
-        x.encode_utf8(&mut buffer);
-        writer.write(&buffer).unwrap();
+        write!(writer, "{}", x).unwrap();
         return Ok(RickrollObject::Undefined);
     }
     return Err(Error::new(ErrorType::RuntimeError, "Wrong type of arguments for PutChar", None));

--- a/src/util.rs
+++ b/src/util.rs
@@ -140,17 +140,11 @@ impl Scope {
         self.contexts.append(&mut contexts);
     }
 
-    pub fn head(&mut self) -> &Context {
-        return &self.contexts[0];
-    }
-
     pub fn behead(&mut self) -> Vec<Context> {
         if self.contexts.len() < 2 {
             panic!("Empty or unit scope cannot be beheaded");
         }
-        let tail = Vec::from(&self.contexts[1..]);
-        self.contexts.truncate(1);
-        return tail;
+        return self.contexts.split_off(1);
     }
 
     pub fn get_global(&mut self) -> &mut Context {


### PR DESCRIPTION
The current implementation of `PutChar` causes 3 null bytes to be output after each character.

Example program:
```
[Chorus]
Never gonna let x down
Never gonna give x 'x'
Never gonna run PutChar and desert x
```

Output (in hex):
```
78 00 00 00
```

This PR fixes the `PutChar` function by using the `write!` macro instead of manually encoding each character.