### PR TITLE
Use Rc for arrays to improve performance

### DIFF
--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -5,6 +5,7 @@ use lazy_static::lazy_static;
 
 use std::collections::HashMap;
 use std::io::{BufRead, Write};
+use std::rc::Rc;
 
 type LibFunction = fn(Vec<RickrollObject>, &mut dyn Write, &mut dyn BufRead) -> Result<RickrollObject, Error>;
 
@@ -23,7 +24,7 @@ lazy_static! {
 }
 
 fn array_of(args: Vec<RickrollObject>, _: &mut dyn Write, _: &mut dyn BufRead) -> Result<RickrollObject, Error> {
-    return Ok(RickrollObject::Array(args));
+    return Ok(RickrollObject::Array(Rc::new(args)));
 }
 
 fn array_pop(args: Vec<RickrollObject>, _: &mut dyn Write, _: &mut dyn BufRead) -> Result<RickrollObject, Error> {
@@ -32,11 +33,12 @@ fn array_pop(args: Vec<RickrollObject>, _: &mut dyn Write, _: &mut dyn BufRead) 
     }
     let arr = args[0].clone();
     let idx = args[1].clone();
-    if let RickrollObject::Array(mut x) = arr {
+    if let RickrollObject::Array(x) = arr {
+        let mut x = (*x).clone();
         if let RickrollObject::Int(y) = idx {
             if y >= 0 && (y as usize) < x.len() {
                 x.remove(y as usize);
-                return Ok(RickrollObject::Array(x));
+                return Ok(RickrollObject::Array(Rc::new(x)));
             }  else {
                 return Err(Error::new(ErrorType::RuntimeError, "Array Index out of Bounds", None));
             }
@@ -52,11 +54,12 @@ fn array_push(args: Vec<RickrollObject>, _: &mut dyn Write, _: &mut dyn BufRead)
     let arr = args[0].clone();
     let idx = args[1].clone();
     let val = args[2].clone();
-    if let RickrollObject::Array(mut x) = arr {
+    if let RickrollObject::Array(x) = arr {
         if let RickrollObject::Int(y) = idx {
+            let mut x = (*x).clone();
             if y >= 0 && (y as usize) <= x.len() {
                 x.insert(y as usize, val);
-                return Ok(RickrollObject::Array(x));
+                return Ok(RickrollObject::Array(Rc::new(x)));
             } else {
                 return Err(Error::new(ErrorType::RuntimeError, "Array Index out of Bounds", None));
             }
@@ -72,11 +75,12 @@ fn array_replace(args: Vec<RickrollObject>, _: &mut dyn Write, _: &mut dyn BufRe
     let arr = args[0].clone();
     let idx = args[1].clone();
     let val = args[2].clone();
-    if let RickrollObject::Array(mut x) = arr {
+    if let RickrollObject::Array(x) = arr {
         if let RickrollObject::Int(y) = idx {
+            let mut x = (*x).clone();
             if y >= 0 && (y as usize) < x.len() {
                 x[y as usize] = val;
-                return Ok(RickrollObject::Array(x));
+                return Ok(RickrollObject::Array(Rc::new(x)));
             } else {
                 return Err(Error::new(ErrorType::RuntimeError, "Array Index out of Bounds", None));
             }
@@ -121,5 +125,5 @@ fn read_line(args: Vec<RickrollObject>, _: &mut dyn Write, reader: &mut dyn BufR
         }
         arr.push(RickrollObject::Char(c));
     }
-    return Ok(RickrollObject::Array(arr));
+    return Ok(RickrollObject::Array(Rc::new(arr)));
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 
 // collection of data types
 #[derive(Debug, Clone)]
@@ -6,7 +7,7 @@ pub enum RickrollObject {
     Int(i32),
     Float(f32),
     Bool(bool),
-    Array(Vec<RickrollObject>),
+    Array(Rc<Vec<RickrollObject>>),
     Char(char),
     Undefined,
 }
@@ -74,7 +75,7 @@ pub fn from_constant(constant: &String) -> Option<RickrollObject> {
         "TRUE" => Some(RickrollObject::Bool(true)),
         "FALSE" => Some(RickrollObject::Bool(false)),
         "UNDEFINED" => Some(RickrollObject::Undefined),
-        "ARRAY" => Some(RickrollObject::Array(Vec::new())),
+        "ARRAY" => Some(RickrollObject::Array(Rc::new(Vec::new()))),
         _ => None,
     }
 }


### PR DESCRIPTION
Every time an array is accessed, the entire array is cloned (even when we just want to read from the array):
https://github.com/BattleMage0231/rickroll/blob/4e7b7666355abb3cde36818a4017ed3d2aedac9f/src/util.rs#L99-L105

We can avoid cloning the array's `Vec<RickrollObject>` by wrapping it in an `Rc`. A benchmark using https://github.com/yaxollum/rickroll-quine/blob/main/Quine.rickroll shows an 8x performance improvement:

```bash
# on current master:
$ time rickroll Quine.rickroll > /dev/null

real	0m2,063s
user	0m2,046s
sys	0m0,013s

# after using Rc for arrays:
$ time rickroll Quine.rickroll > /dev/null

real	0m0,249s
user	0m0,241s
sys	0m0,008s
```